### PR TITLE
修改 README 中会冲突的链接

### DIFF
--- a/README
+++ b/README
@@ -14,4 +14,4 @@ NEWS 文件中有本软件的特性支持信息与已知问题信息。
 	dedication to be an overt act of relinquishment in perpetuity of all
 	present and future rights to this software under copyright law.
 
-要获取最新二进制文件，访问 Jenkins 下载：https://ci.hackflow.org/job/oicq-axon。
+要获取最新二进制文件，访问 Jenkins 下载：[https://ci.hackflow.org/job/oicq-axon](https://ci.hackflow.org/job/oicq-axon)


### PR DESCRIPTION
原先的 _https://ci.hackflow.org/job/oicq-axon。_ 会导致Github在链接后面加个句号